### PR TITLE
古いキャッシュの削除を更新時もチェック

### DIFF
--- a/src/serviceworker/caches.js
+++ b/src/serviceworker/caches.js
@@ -55,7 +55,9 @@ async function checkForUpdate () {
   const assets = await fetchAssetsJson()
   if (await cacheExists(assets.version)) {
     debug('already up-to-date')
-    return
+    // まれにupdateCacheで古いキャッシュの削除に失敗することがあるので
+    // 念の為このタイミングで古いキャッシュがないことを確認する
+    return deleteOldCache(assets.version)
   }
   return updateCache(assets)
 }


### PR DESCRIPTION
いろいろ実験してる過程で、以下のような例外的な事案に遭遇

caches.addAll が完了。古いキャッシュの削除中に、（たぶんserviceworkerが停止するなどして）停止

cacheが新旧二つある状態になった。

この状態で、アクセスすると、古い方からキャッシュが提供され、「新バージョンがある」とでるが、何度リロードしても、これが繰り返され、無限ループ状態になる。

この事態に対応するため、アクセス時に、古いキャッシュを念の為毎回消す処理をいれることにした
