### PR TITLE
jsonはrequire文で読み込めるのでmz npmは不要

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -315,11 +315,6 @@
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -4799,16 +4794,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "nan": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
@@ -6739,22 +6724,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "requires": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "requires": {
-        "thenify": ">= 3.1.0 < 4"
-      }
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "font-awesome": "^4.6.3",
     "highlight.js": "^9.12.0",
     "morgan": "^1.9.0",
-    "mz": "^2.7.0",
     "node-sass": "^4.9.0",
     "npm-run-all": "^4.1.3",
     "path": "^0.12.7",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,9 +1,9 @@
 const express = require('express')
 const app = express()
 const path = require('path')
-const fs = require('mz/fs')
 const morgan = require('morgan')
 const forceSSL = require('express-force-ssl')
+const assets = require('../../public/assets/assets.json')
 
 app.use(morgan('dev'))
 if (process.env.FORCE_SSL === 'true') {
@@ -11,23 +11,17 @@ if (process.env.FORCE_SSL === 'true') {
   app.use(forceSSL)
 }
 
-app.get('/', async (req, res) => {
-  const version = await readAssetsVersion()
+app.get('/', (req, res) => {
+  const version = assets.version
   res.setHeader('x-assets-version', version)
   res.render('app', {version})
 })
 
-app.get('/app.html', async (req, res) => {
-  const version = await readAssetsVersion()
+app.get('/app.html', (req, res) => {
+  const version = assets.version
   res.setHeader('x-assets-version', version)
   res.render('app', {version})
 })
-
-async function readAssetsVersion () {
-  const json = await fs.readFile('./public/assets/assets.json')
-  const {version} = JSON.parse(json)
-  return version
-}
 
 app.get('/note/*', (req, res) => {
   res.render('app')


### PR DESCRIPTION
assets.jsonの読み込みにrequire文を使います。サーバー起動時にオンメモリに読み込んでしまい、リクエスト毎には読み込まなくなりました。

`fs.readFileSync` でも良い。

いずれにせよ単に同期的にファイルを読み込むためには[mz](https://www.npmjs.com/package/mz)は不要です。これに依存して何か細かいnpmが色々installされているのも気になった