### PR TITLE
ServiceWorkerでImport/export文を使う

### DIFF
--- a/src/serviceworker/.babelrc
+++ b/src/serviceworker/.babelrc
@@ -1,3 +1,10 @@
 {
-  "presets": []
+  "presets": [
+    "stage-3",
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions"]
+      }
+    }]
+  ]
 }

--- a/src/serviceworker/.babelrc
+++ b/src/serviceworker/.babelrc
@@ -1,10 +1,6 @@
 {
-  "presets": [
-    "stage-3",
-    ["env", {
-      "targets": {
-        "browsers": ["last 2 versions"]
-      }
-    }]
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-object-rest-spread"
   ]
 }

--- a/src/serviceworker/caches.js
+++ b/src/serviceworker/caches.js
@@ -13,7 +13,7 @@ async function updateCache ({version, urls}) {
   return {version}
 }
 
-async function deleteAllCache () {
+export async function deleteAllCache () {
   debug('delete all cache')
   const keys = await caches.keys()
   return Promise.all(keys.map(key => caches.delete(key)))
@@ -45,7 +45,7 @@ async function cacheExists (version) {
   return (await cache.keys()).length > 0
 }
 
-async function checkForUpdate () {
+export async function checkForUpdate () {
   debug('checking for update...')
   if (!navigator.onLine) {
     debug('offline')
@@ -62,4 +62,3 @@ async function checkForUpdate () {
   return updateCache(assets)
 }
 
-module.exports = {deleteAllCache, checkForUpdate}

--- a/src/serviceworker/caches.js
+++ b/src/serviceworker/caches.js
@@ -61,4 +61,3 @@ export async function checkForUpdate () {
   }
   return updateCache(assets)
 }
-

--- a/src/serviceworker/caches.js
+++ b/src/serviceworker/caches.js
@@ -1,4 +1,4 @@
-/* eslint-env browser */
+/* eslint-env worker, serviceworker */
 
 const isDebug = () => location && ['localhost', 'sw-skelton.herokuapp.com'].includes(location.hostname)
 const debug = (...msg) => isDebug() && console.log('%cserviceworker:caches', 'color: gray', ...msg)

--- a/src/serviceworker/index.js
+++ b/src/serviceworker/index.js
@@ -1,5 +1,4 @@
-/* global caches self URL fetch */
-/* eslint-env browser */
+/* eslint-env worker, serviceworker */
 
 import {deleteAllCache, checkForUpdate} from './caches'
 import {isSinglePageRequest, createSinglePageRequest} from './single-page-request'

--- a/src/serviceworker/index.js
+++ b/src/serviceworker/index.js
@@ -4,8 +4,8 @@
 const isDebug = () => location && ['localhost', 'sw-skelton.herokuapp.com'].includes(location.hostname)
 const debug = (...msg) => isDebug() && console.log('%cserviceworker', 'color: gray', ...msg)
 
-const {deleteAllCache, checkForUpdate} = require('./caches')
-const {isSinglePageRequest, createSinglePageRequest} = require('./single-page-request')
+import {deleteAllCache, checkForUpdate} from './caches'
+import {isSinglePageRequest, createSinglePageRequest} from './single-page-request'
 
 debug('start')
 

--- a/src/serviceworker/index.js
+++ b/src/serviceworker/index.js
@@ -1,11 +1,11 @@
 /* global caches self URL fetch */
 /* eslint-env browser */
 
-const isDebug = () => location && ['localhost', 'sw-skelton.herokuapp.com'].includes(location.hostname)
-const debug = (...msg) => isDebug() && console.log('%cserviceworker', 'color: gray', ...msg)
-
 import {deleteAllCache, checkForUpdate} from './caches'
 import {isSinglePageRequest, createSinglePageRequest} from './single-page-request'
+
+const isDebug = () => location && ['localhost', 'sw-skelton.herokuapp.com'].includes(location.hostname)
+const debug = (...msg) => isDebug() && console.log('%cserviceworker', 'color: gray', ...msg)
 
 debug('start')
 

--- a/src/serviceworker/single-page-request.js
+++ b/src/serviceworker/single-page-request.js
@@ -37,7 +37,7 @@ function isGetMethod (req) {
   return req.method === 'GET'
 }
 
-function isSinglePageRequest (req) {
+export function isSinglePageRequest (req) {
   const url = new URL(req.url)
 
   return (
@@ -49,7 +49,7 @@ function isSinglePageRequest (req) {
   )
 }
 
-function createSinglePageRequest (req) {
+export function createSinglePageRequest (req) {
   const url = new URL(req.url).origin + '/app.html'
   return new Request(url, {
     method: req.method,
@@ -60,5 +60,3 @@ function createSinglePageRequest (req) {
     redirect: 'manual' // let browser handle redirects
   })
 }
-
-module.exports = {isSinglePageRequest, createSinglePageRequest}

--- a/src/serviceworker/single-page-request.js
+++ b/src/serviceworker/single-page-request.js
@@ -1,4 +1,4 @@
-/* eslint-env browser */
+/* eslint-env worker, serviceworker */
 
 const NOCACHE_PATHS = [
   '/serviceworker.js',


### PR DESCRIPTION
## 変更

- serviceworker用の `.babelrc` を書き、require文をimport/exportに書き換えた
- eslint-envはserviceworker用の設定があった
  - https://eslint.org/docs/user-guide/configuring#specifying-environments

## 動作確認方法

- 準備
  - `npm run start:dev` でserverを起動
  - Disable service workerボタンを押してserviceworkerをアンインストールし、再インストールする

これでserverを止めてもオフライン表示できればok
