### PR TITLE
ServiceWorkerとのpostMessageフォーマットを {title, body} に変更

### DIFF
--- a/src/client/js/components/setting.js
+++ b/src/client/js/components/setting.js
@@ -48,7 +48,7 @@ export default class Setting extends Component {
 
     this.setState({loading: true})
     try {
-      const res = await ServiceWorkerClient.postMessage({name: 'checkForUpdate'})
+      const res = await ServiceWorkerClient.postMessage({title: 'checkForUpdate'})
       debug(res)
       // await AssetsCacheStore.checkForUpdate()
     } catch (err) {

--- a/src/client/js/components/setting.js
+++ b/src/client/js/components/setting.js
@@ -48,7 +48,7 @@ export default class Setting extends Component {
 
     this.setState({loading: true})
     try {
-      const res = await ServiceWorkerClient.postMessage('checkForUpdate')
+      const res = await ServiceWorkerClient.postMessage({name: 'checkForUpdate'})
       debug(res)
       // await AssetsCacheStore.checkForUpdate()
     } catch (err) {

--- a/src/client/js/lib/serviceworker-client.js
+++ b/src/client/js/lib/serviceworker-client.js
@@ -41,19 +41,19 @@ async function update () {
   return reg.update() // service worker自体の更新を行う
 }
 
-async function postMessage ({name, data}) {
+async function postMessage ({title, body}) {
   const reg = await getRegistration()
   if (!reg || !reg.active) throw new Error('Service worker is not active yet')
   // Note: postMessageが呼ばれると、service workerがstopしていてもstartされる
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel()
-    channel.port1.onmessage = e => {
-      if (e.data && e.data.error) {
-        reject(e.data.error)
+    channel.port1.onmessage = event => {
+      if (event.data && event.data.error) {
+        reject(event.data.error)
       } else {
-        resolve(e.data)
+        resolve(event.data)
       }
     }
-    reg.active.postMessage({name, data}, [channel.port2])
+    reg.active.postMessage({title, body}, [channel.port2])
   })
 }

--- a/src/client/js/lib/serviceworker-client.js
+++ b/src/client/js/lib/serviceworker-client.js
@@ -41,7 +41,7 @@ async function update () {
   return reg.update() // service worker自体の更新を行う
 }
 
-async function postMessage (message) {
+async function postMessage ({name, data}) {
   const reg = await getRegistration()
   if (!reg || !reg.active) throw new Error('Service worker is not active yet')
   // Note: postMessageが呼ばれると、service workerがstopしていてもstartされる
@@ -54,6 +54,6 @@ async function postMessage (message) {
         resolve(e.data)
       }
     }
-    reg.active.postMessage(message, [channel.port2])
+    reg.active.postMessage({name, data}, [channel.port2])
   })
 }

--- a/src/serviceworker/message/index.js
+++ b/src/serviceworker/message/index.js
@@ -4,16 +4,21 @@ import {checkForUpdate} from '../lib/caches'
 const debug = require('../lib/debug')(__filename)
 
 self.addEventListener('message', function (event) {
-  debug(event.data)
-  const {name, data} = event.data // eslint-disable-line no-unused-vars
-  if (name !== 'checkForUpdate') return
   event.waitUntil(async function () {
     try {
-      const result = await checkForUpdate()
-      event.ports[0].postMessage({name, result})
+      const result = await exec(event.data)
+      event.ports[0].postMessage({name: event.name, result})
     } catch (err) {
       console.error(err)
-      event.ports[0].postMessage({name, error: err.message})
+      event.ports[0].postMessage({name: event.name, error: err.message})
     }
   }())
 })
+
+function exec ({name, data}) {
+  debug('exec', {name, data})
+  switch (name) {
+    case 'checkForUpdate':
+      return checkForUpdate()
+  }
+}

--- a/src/serviceworker/message/index.js
+++ b/src/serviceworker/message/index.js
@@ -7,17 +7,17 @@ self.addEventListener('message', function (event) {
   event.waitUntil(async function () {
     try {
       const result = await exec(event.data)
-      event.ports[0].postMessage({name: event.name, result})
+      event.ports[0].postMessage({title: event.title, result})
     } catch (err) {
       console.error(err)
-      event.ports[0].postMessage({name: event.name, error: err.message})
+      event.ports[0].postMessage({title: event.title, error: err.message})
     }
   }())
 })
 
-function exec ({name, data}) {
-  debug('exec', {name, data})
-  switch (name) {
+function exec ({title, body}) {
+  debug('exec', {title, body})
+  switch (title) {
     case 'checkForUpdate':
       return checkForUpdate()
   }

--- a/src/serviceworker/message/index.js
+++ b/src/serviceworker/message/index.js
@@ -5,15 +5,15 @@ const debug = require('../lib/debug')(__filename)
 
 self.addEventListener('message', function (event) {
   debug(event.data)
+  const {name, data} = event.data // eslint-disable-line no-unused-vars
+  if (name !== 'checkForUpdate') return
   event.waitUntil(async function () {
-    if (event.data !== 'checkForUpdate') return
-    let ret
     try {
-      ret = await checkForUpdate()
+      const result = await checkForUpdate()
+      event.ports[0].postMessage({name, result})
     } catch (err) {
       console.error(err)
-      ret = {error: err.message}
+      event.ports[0].postMessage({name, error: err.message})
     }
-    event.ports[0].postMessage(ret)
   }())
 })


### PR DESCRIPTION
#36 で言っていた、UIスレッド-ServiceWorker間のpostMessageのフォーマット変更です。
今後拡張する時に絶対困るので、早めに直しておきたい。

## これまで

- UIスレッド→ServiceWorker
  - `event.data` に直接stringでメッセージを入れていた
  - メッセージの型と引数をそれぞれ送りたくなるので、 `event.data` に直接stringを入れるのをやめたい
- ServiceWorker→UIスレッド
  - `event.data` はエラーがあれば `{error: string}`
  - エラーが無ければ自由な値を返せる
  - 返り値にたまたまerrorというプロパティが含まれているとエラー扱いになってしまう

## 修正

- UIスレッド→ServiceWorker
  - `{title, body}` を送る
  - client jsのServiceWorkerClientも、 `postMessage({title, body})` に変更した
- ServiceWorker→UIスレッド
  - `{title, result, error}` を返す
    - エラーがある時だけerrorは存在する
    - 成功した時だけresultは存在する


## 動作確認方法

Check for Updateボタンを押す

nodejs serverが起動している場合、ブラウザの開発コンソールに完了メッセージが表示される

[![Screenshot from Gyazo](https://gyazo.com/d529e540cb7ac3d4feb3cc46591ab9d9/raw)](https://gyazo.com/d529e540cb7ac3d4feb3cc46591ab9d9)

nodejs serverが起動していない場合、UIスレッド側にfetchが失敗したというalertが表示される

[![Screenshot from Gyazo](https://gyazo.com/21e76edd98896552e2998e9e65eb7e8f/raw)](https://gyazo.com/21e76edd98896552e2998e9e65eb7e8f)
