### PR TITLE
オフライン時にserviceworkerがcheckForUpdateした時のエラーメッセージをUIスレッドに返す

### DIFF
--- a/src/serviceworker/lib/caches.js
+++ b/src/serviceworker/lib/caches.js
@@ -47,8 +47,7 @@ async function cacheExists (version) {
 export async function checkForUpdate () {
   debug('checking for update...')
   if (!navigator.onLine) {
-    debug('offline')
-    return
+    throw new Error('network is offline')
   }
 
   const assets = await fetchAssetsJson()

--- a/src/serviceworker/message/index.js
+++ b/src/serviceworker/message/index.js
@@ -7,10 +7,10 @@ self.addEventListener('message', function (event) {
   event.waitUntil(async function () {
     try {
       const result = await exec(event.data)
-      event.ports[0].postMessage({title: event.title, result})
+      event.ports[0].postMessage({title: event.data.title, result})
     } catch (err) {
       console.error(err)
-      event.ports[0].postMessage({title: event.title, error: err.message})
+      event.ports[0].postMessage({title: event.data.title, error: err.message})
     }
   }())
 })


### PR DESCRIPTION
オフライン時にserviceworkerがcheckForUpdateした時に、エラーメッセージが返っていませんでした。
返すようにしました。